### PR TITLE
docker起動時コンテナが必ずしも起動しないようにした

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
   web:
     build: .
-    restart: always
+    restart: unless-stopped
     command: >
       sh -c "uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
     volumes:


### PR DESCRIPTION
Dockerを起動したら毎回バックエンドのコンテナが起動するので困ってます
前回のDockerエンジン終了時にコンテナが停止していたら次のDockerエンジン起動時にコンテナを起動しないように設定しました